### PR TITLE
strip() before split() so that newline character at end of file is ignored

### DIFF
--- a/pg_explain_locks.py
+++ b/pg_explain_locks.py
@@ -129,7 +129,7 @@ def parse_args_from_settings_file():
     args = {}
     with open(SETTINGS_FILE, 'r') as settings_file:
         content = settings_file.read()
-        lines = content.trim().split('\n')
+        lines = content.strip().split('\n')
         for line in lines:
             setting, value = line.split('=')
             args[setting.lower()] = value

--- a/pg_explain_locks.py
+++ b/pg_explain_locks.py
@@ -129,7 +129,7 @@ def parse_args_from_settings_file():
     args = {}
     with open(SETTINGS_FILE, 'r') as settings_file:
         content = settings_file.read()
-        lines = content.split('\n')
+        lines = content.trim().split('\n')
         for line in lines:
             setting, value = line.split('=')
             args[setting.lower()] = value


### PR DESCRIPTION
It is common practice to end files with a newline character, and many editors will add this automatically. Right now, an additional newline character will cause a failure when reading the settings file: 

```python
line 134, in parse_args_from_settings_file
    setting, value = line.split('=')
ValueError: not enough values to unpack (expected 2, got 1)
```